### PR TITLE
Fix article dir calculation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: URL of contribution guide
     required: false
     default: ""
+  debug:
+    description: Show additional info to aid debugging
+    required: false
+
 
 runs:
   using: docker

--- a/check.py
+++ b/check.py
@@ -39,10 +39,10 @@ def main(articles_dir, ignore_list=None, category_list=None, contrib_url=None) -
             print(f"Skipped on title prefix: {ignored}")
             return 0
 
-        for label in event["pull_request"]["labels"]:
-            if label["name"] == ignored:
-                print(f"Skipped on PR label: {label['name']}")
-                return 0
+    for label in event["pull_request"]["labels"]:
+        if label["name"] in ignored_labels:
+            print(f"Skipped on PR label: {label['name']}")
+            return 0
 
     pull_request_number = event["pull_request"]["number"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+ARTICLE_DIR="${PWD}/${INPUT_ARTICLE_DIR}"
+
 if [[ "${INPUT_DEBUG,,}" == "true" ]]; then
   echo "=== Debug Mode Enabled ==="
-  ls -al ${INPUT_ARTICLE_DIR}
+  echo "Article dir: ${ARTICLE_DIR}"
+  ls -al ${ARTICLE_DIR}
 fi
 
 cd /action
@@ -10,4 +13,4 @@ cd /action
 python check.py --categories=${INPUT_CATEGORIES}         \
                 --ignores=${INPUT_IGNORES}               \
                 --contrib_guide_url=${INPUT_CONTRIB_URL} \
-                ${INPUT_ARTICLE_DIR}
+                ${ARTICLE_DIR}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ "${INPUT_DEBUG,,}" == "true" ]]; then
+  echo "=== Debug Mode Enabled ==="
+  ls -al ${INPUT_ARTICLE_DIR}
+fi
+
 cd /action
 
 python check.py --categories=${INPUT_CATEGORIES}         \

--- a/test.py
+++ b/test.py
@@ -6,16 +6,18 @@ import check as checker
 # returns:
 #  1: OK
 #  0: Not OK
-def check(event, ignores=None, categories=None, contrib_url=None):
+def passing(event, dir, ignores=None, categories=None, contrib_url=None):
     os.environ["EVENT_PATH"] = f"test/{event}.json"
-    return not checker.main("test", ignores, categories, contrib_url)
+    return not checker.main(f"test/{dir}", ignores, categories, contrib_url)
 
 
 def test_simple():
-    assert not check("e0")
+    assert passing("e0", "news1")
+    assert not passing("e3", "news1")
+    assert passing("e3", "news3")
 
 
 def test_ignore():
-    assert not check("e2")
-    assert check("e2", ignores="ignore")
-    assert check("e2", ignores="ignore,foo")
+    assert not passing("e2", "news2")
+    assert passing("e2", "news2", ignores="ignore")
+    assert passing("e2", "news2", ignores="ignore,foo")

--- a/test/e3.json
+++ b/test/e3.json
@@ -1,0 +1,7 @@
+{
+  "pull_request": {
+    "number": 456,
+    "title": "simple",
+    "labels": []
+  }
+}


### PR DESCRIPTION
The article dir was being distorted in the entry point script

This fixes the issue by performing the calculation prior to changing to the action dir in the container.

This also adds a debug flag to print out additional information when working through an issue.